### PR TITLE
feat(test): pass cli args to jest

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -2,7 +2,11 @@ const jest = require('jest');
 const jestConfig = require('../config/jest.config');
 
 module.exports = (argv) => {
-  const jestArgs = ['--config', JSON.stringify(jestConfig)];
+  const jestArgs = [...argv._, '--config', JSON.stringify(jestConfig)];
+
+  // remove first entry as it's the 'test' command of this file
+  jestArgs.shift();
+
   if (argv.coverage) {
     jestArgs.push('--coverage');
   }


### PR DESCRIPTION
Enables the possibility to run tests like:

`yarn test nameOfMyTest`

to not run the whole test suite but the test matching `/nameOfMyTest/i`